### PR TITLE
Peek checks expiration

### DIFF
--- a/src/cache.sol
+++ b/src/cache.sol
@@ -25,7 +25,7 @@ contract DSCache is DSValue
 //    bool    has;
 //    bytes32 val;
     function peek() constant returns (bytes32, bool) {
-        return (val,has);
+        return (val, has && now < zzz);
     }
     function read() constant returns (bytes32) {
         var (wut, has) = peek();


### PR DESCRIPTION
In order to let the medianizer checking the status of a DSCache or a DSValue in a transparent way, it is better to make the boolean value of the `peek` method to also check the expiration in this case.